### PR TITLE
Update pipelines

### DIFF
--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           kibot -c Kicad/docs.kibot.yml -e ${{env.schema}} -b ${{env.board}} -d ${{env.dir}} -s run_erc,run_drc -v 
       - name: Upload KiBot Output
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{success()}}
         with:
           name: Build-Outputs

--- a/.github/workflows/kibot.yml
+++ b/.github/workflows/kibot.yml
@@ -27,18 +27,22 @@ jobs:
   DRC:
     runs-on: ubuntu-latest
     container:
-      image: setsoft/kicad_auto:dev_k6
+      image: setsoft/kicad_auto:ki6.0.7_Debian
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+            submodules: true
       - name: Run KiBot for DRC
         run: |
           kibot -c Kicad/docs.kibot.yml -e ${{env.schema}} -b ${{env.board}} -d ${{env.dir}} -s run_drc -v -i
   ERC:
     runs-on: ubuntu-latest
     container:
-      image: setsoft/kicad_auto:dev_k6
+      image: setsoft/kicad_auto:ki6.0.7_Debian
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+            submodules: true
       - name: Run KiBot for ERC
         run: |
           kibot -c Kicad/docs.kibot.yml -e ${{env.schema}} -b ${{env.board}} -d ${{env.dir}} -s run_erc -v -i
@@ -46,9 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ERC, DRC]
     container:
-      image: setsoft/kicad_auto:dev_k6
+      image: setsoft/kicad_auto:ki6.0.7_Debian
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+            submodules: true
       - name: Get Branch Name
         if: github.event_name == 'push' && startswith(github.ref, 'refs/tags/')
         id: branch_name


### PR DESCRIPTION
Pins Kicad to 6.0.7 to avoid #140.

Update upload-artifact to @v3 to avoid node warning in GHA.
Ensure submodules are fetched (for Neotron-Common-Hardware).